### PR TITLE
remove the extra dom when destory the component

### DIFF
--- a/vue-flatpickr-default.vue
+++ b/vue-flatpickr-default.vue
@@ -6,28 +6,34 @@
 import Flatpickr from './assets/flatpickr'
 
 export default {
-	props: {
-    options: {
-      type: Object,
-      default: () => {
-      	return {}
-      }
+    data() {
+        return {
+            fp: null
+        }
     },
-    message: {
-    	type: String,
-    	default: () => {
-    		return ''
-    	}
-    }
-  },
+	props: {
+        options: {
+            type: Object,
+            default: () => {
+      	         return {}
+             }
+         },
+         message: {
+    	        type: String,
+    	           default: () => ''
+        }
+    },
 	methods: {
-		inputting (e) {
-			this.$emit('update', e.target.value)
+        inputting (e) {
+            this.$emit('update', e.target.value)
 		}
 	},
-  mounted () {
-    new Flatpickr(this.$el, this.options)
-  }
+    mounted () {
+        this.fp = new Flatpickr(this.$el, this.options)
+    },
+    destroyed() {
+        this.fp.destroy()
+    }
 }
 </script>
 


### PR DESCRIPTION
Everytime you `new Flatpickr`, it will create a fixed dom in `body` which is the calendar it shows. It will be fine if your application will never touch `flatpickr`, but when it comes to dynamic component, you may create or destory `flatpickr` frequently. So you may create lots of useless dom in your application. To remove that, just destroy it when you destroy this component.

One more thing, I make this change just in `vue-flatpickr-default.js`.