### PR TITLE
Emit function to get the Flatpickr reference in Vue

### DIFF
--- a/vue-flatpickr-airbnb.vue
+++ b/vue-flatpickr-airbnb.vue
@@ -30,6 +30,7 @@ export default {
 	},
   mounted () {
     this.fp = new Flatpickr(this.$el, this.options)
+    this.$emit('FlatpickrRef', this.fp);
   },
   destroyed() {
     this.fp.destroy()

--- a/vue-flatpickr-base16.vue
+++ b/vue-flatpickr-base16.vue
@@ -30,6 +30,7 @@ export default {
   },
   mounted () {
     this.fp = new Flatpickr(this.$el, this.options)
+    this.$emit('FlatpickrRef', this.fp)
   },
   destroyed() {
     this.fp.destroy()

--- a/vue-flatpickr-confetti.vue
+++ b/vue-flatpickr-confetti.vue
@@ -30,6 +30,7 @@ export default {
   },
   mounted () {
     this.fp = new Flatpickr(this.$el, this.options)
+    this.$emit('FlatpickrRef', this.fp);
   },
   destroyed() {
     this.fp.destroy()

--- a/vue-flatpickr-dark.vue
+++ b/vue-flatpickr-dark.vue
@@ -30,6 +30,7 @@ export default {
   },
   mounted () {
     this.fp = new Flatpickr(this.$el, this.options)
+    this.$emit('FlatpickrRef', this.fp);
   },
   destroyed() {
     this.fp.destroy()

--- a/vue-flatpickr-default.vue
+++ b/vue-flatpickr-default.vue
@@ -30,6 +30,7 @@ export default {
   },
   mounted () {
     this.fp = new Flatpickr(this.$el, this.options)
+    this.$emit('FlatpickrRef', this.fp);
   },
   destroyed() {
     this.fp.destroy()

--- a/vue-flatpickr-material_blue.vue
+++ b/vue-flatpickr-material_blue.vue
@@ -30,6 +30,7 @@ export default {
   },
   mounted () {
     this.fp = new Flatpickr(this.$el, this.options)
+    this.$emit('FlatpickrRef', this.fp);
   },
   destroyed() {
     this.fp.destroy()

--- a/vue-flatpickr-material_green.vue
+++ b/vue-flatpickr-material_green.vue
@@ -30,6 +30,7 @@ export default {
   },
   mounted () {
     this.fp = new Flatpickr(this.$el, this.options)
+    this.$emit('FlatpickrRef', this.fp);
   },
   destroyed() {
     this.fp.destroy()

--- a/vue-flatpickr-material_orange.vue
+++ b/vue-flatpickr-material_orange.vue
@@ -30,6 +30,7 @@ export default {
   },
   mounted () {
     this.fp = new Flatpickr(this.$el, this.options)
+    this.$emit('FlatpickrRef', this.fp);
   },
   destroyed() {
     this.fp.destroy()

--- a/vue-flatpickr-material_red.vue
+++ b/vue-flatpickr-material_red.vue
@@ -30,6 +30,7 @@ export default {
   },
   mounted () {
     this.fp = new Flatpickr(this.$el, this.options)
+    this.$emit('FlatpickrRef', this.fp);
   },
   destroyed() {
     this.fp.destroy()


### PR DESCRIPTION
In the different *.vue files I added an emit function to get a reference on the original Flatpickr Object.
So in Vue. We can now handle on the fly modifications (options, redraw, etc..).

It could be usefull if you want to update a second Flatpickr input when you just filled a first one.
(air booking websites for example)