### PR TITLE
Removed string type for value

### DIFF
--- a/src/components/vue-flatpickr.vue
+++ b/src/components/vue-flatpickr.vue
@@ -19,7 +19,6 @@ export default {
       default: () => { return {} }
     },
     value: {
-      type: String,
       default: ''
     }
   },


### PR DESCRIPTION
Flatpickr can except a range of date types
https://chmln.github.io/flatpickr/examples/#supplying-dates-for-flatpickr
string, number, or date object